### PR TITLE
add for LSP support

### DIFF
--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,0 +1,6 @@
+-Wall
+-I./Drivers/Device
+-I./Src/inc
+-I./Src/peripherals
+-I./Src/system_config
+-I./Src/tools


### PR DESCRIPTION
Add `compile_flags.txt` for clangd support. This allows people to use any editor with clangd for linting instead of CubeIDE which looks ugly.